### PR TITLE
feat: add list only argument to install and auto-install

### DIFF
--- a/cmd/auto-install.go
+++ b/cmd/auto-install.go
@@ -15,6 +15,7 @@ func NewAutoInstallCmd() *cmdr.Command {
 		autoInstall,
 	)
 	cmd.Flags().BoolP("list-only", "l", false, ikaros.Trans("autoInstall.listOnly"))
+	cmd.Args = cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs)
 	cmd.Example = "ikaros auto-install"
 
 	return cmd

--- a/cmd/auto-install.go
+++ b/cmd/auto-install.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/ikaros/core"
 	"github.com/vanilla-os/orchid/cmdr"
@@ -13,15 +14,22 @@ func NewAutoInstallCmd() *cmdr.Command {
 		ikaros.Trans("autoInstall.short"),
 		autoInstall,
 	)
-	cmd.Args = cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
+	cmd.Flags().BoolP("list-only", "l", false, ikaros.Trans("autoInstall.listOnly"))
 	cmd.Example = "ikaros auto-install"
 
 	return cmd
 }
 
 func autoInstall(cmd *cobra.Command, args []string) error {
-	spinner, _ := cmdr.Spinner.Start(ikaros.Trans("autoInstall.startInstallation"))
-	err := core.DriversManager{}.AutoInstallDrivers()
+	listonly, _ := cmd.Flags().GetBool("list-only")
+	var spinner *pterm.SpinnerPrinter
+	if !listonly {
+		spinner, _ = cmdr.Spinner.Start(ikaros.Trans("autoInstall.startInstallation"))
+	}
+	err := core.DriversManager{}.AutoInstallDrivers(listonly)
+	if spinner == nil {
+		return nil
+	}
 	if err != nil {
 		spinner.Fail(ikaros.Trans("autoInstall.failedInstallation"))
 		return err

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/vanilla-os/ikaros/core"
 	"github.com/vanilla-os/orchid/cmdr"
@@ -13,6 +16,7 @@ func NewInstallCmd() *cmdr.Command {
 		ikaros.Trans("install.short"),
 		install,
 	)
+	cmd.Flags().BoolP("list-only", "l", false, ikaros.Trans("install.listOnly"))
 	cmd.Args = cobra.MinimumNArgs(1)
 	cmd.Example = "ikaros install"
 
@@ -20,6 +24,19 @@ func NewInstallCmd() *cmdr.Command {
 }
 
 func install(cmd *cobra.Command, args []string) error {
+	listonly, _ := cmd.Flags().GetBool("list-only")
+	if listonly {
+		device, err := core.DriversManager{}.GetDeviceByID(args[0])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, ikaros.Trans("install.failedGetDevice"))
+			return err
+		}
+
+		drivers := core.PkgListDrivers(device)
+		fmt.Printf("%s", drivers[0])
+		return nil
+	}
+
 	spinner, _ := cmdr.Spinner.Start(ikaros.Trans("install.startInstallation"))
 	device, err := core.DriversManager{}.GetDeviceByID(args[0])
 	if err != nil {

--- a/core/manager.go
+++ b/core/manager.go
@@ -103,10 +103,17 @@ func (m DriversManager) GetDeviceByID(id string) (Device, error) {
 	return Device{}, fmt.Errorf("device not found")
 }
 
-func (m DriversManager) AutoInstallDrivers() error {
+func (m DriversManager) AutoInstallDrivers(listonly bool) error {
 	devicesMap := m.GetDevices()
 	for _, devices := range devicesMap {
 		for _, device := range devices {
+			if listonly {
+				drivers := PkgListDrivers(device)
+				if len(drivers) > 0 {
+					fmt.Printf("%s ", drivers[0])
+				}
+				continue
+			}
 			err := m.InstallDriver(device)
 			if err != nil {
 				return err


### PR DESCRIPTION
Related to #21 

I also changed the requirement for number of arguments in `auto-install` to 0, since no positional arguments apply there.  
I wasn't sure how translations are handled so translation key for new command flag is not added to translation files